### PR TITLE
Add clustering into Luigi data pipeline

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -10,10 +10,14 @@ password
 schema = lyon
 table = timeserie
 daily_transaction = daily_transaction
+clustering = clustered_stations
+centroids = centroids
 
 [bordeaux]
 schema = bordeaux
 table = timeserie
 daily_transaction = daily_transaction
+clustering = clustered_stations
+centroids = centroids
 # API Key
 key = QHUHHRI7HD

--- a/jitenshea/controller.py
+++ b/jitenshea/controller.py
@@ -419,23 +419,3 @@ def daily_profile(city, station_ids, day, window):
             'sum': profile['sum'].values.tolist(),
             'mean': profile['mean'].values.tolist()})
     return {"data": result, "date": day, "window": window}
-
-def insert_rows(df, conn, schema, table):
-    """Insert `df` rows into table `table` of schema ̀schema`
-
-    Parameters
-    ----------
-    df : pandas.DataFrame
-        DataFrame that contains data to insert in base
-    conn : psycopg2.extension.cursor
-        Database connection object
-    schema : str
-        Name of the schema
-    table : str
-        Name of the table that will be fulfilled
-    """
-    insert_query = "INSERT INTO {} VALUES ({});"
-    for _, row in df.iterrows():
-        schtable = ".".join([schema, table])
-        values = ", ".join(str(rv) for rv in row.values)
-        conn.execute(insert_query.format(schtable, values))

--- a/jitenshea/controller.py
+++ b/jitenshea/controller.py
@@ -419,3 +419,23 @@ def daily_profile(city, station_ids, day, window):
             'sum': profile['sum'].values.tolist(),
             'mean': profile['mean'].values.tolist()})
     return {"data": result, "date": day, "window": window}
+
+def insert_rows(df, conn, schema, table):
+    """Insert `df` rows into table `table` of schema ̀schema`
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame that contains data to insert in base
+    conn : psycopg2.extension.cursor
+        Database connection object
+    schema : str
+        Name of the schema
+    table : str
+        Name of the table that will be fulfilled
+    """
+    insert_query = "INSERT INTO {} VALUES ({});"
+    for _, row in df.iterrows():
+        schtable = ".".join([schema, table])
+        values = ", ".join(str(rv) for rv in row.values)
+        conn.execute(insert_query.format(schtable, values))

--- a/jitenshea/stats.py
+++ b/jitenshea/stats.py
@@ -25,14 +25,14 @@ def compute_clusters(df):
     for cluster centroids
     
     """
-    df_norm = preprocess_data(df)
+    df_norm = preprocess_data_for_clustering(df)
     model = KMeans(n_clusters=4, random_state=0)
     kmeans = model.fit(df_norm.T)
     df_labels = pd.DataFrame({"id_station": df_norm.columns, "labels": kmeans.labels_})
     df_centroids = pd.DataFrame(kmeans.cluster_centers_).reset_index()
     return {"labels": df_labels, "centroids": df_centroids}
 
-def preprocess_data(df):
+def preprocess_data_for_clustering(df):
     """Prepare data in order to apply a clustering algorithm
 
     Parameters

--- a/jitenshea/stats.py
+++ b/jitenshea/stats.py
@@ -1,0 +1,68 @@
+# coding: utf-8
+
+"""Statistical methods used for analyzing the shared bike data
+"""
+
+
+import numpy as np
+import pandas as pd
+from sklearn.cluster import KMeans
+
+from jitenshea import config
+
+def compute_clusters(df):
+    """Compute station clusters based on bike availability time series
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input data, *i.e.* city-related timeseries, supposed to have
+    `station_id`, `ts` and `nb_bikes` columns
+
+    Returns
+    -------
+    dict
+        Two pandas.DataFrame, the former for station clusters and the latter
+    for cluster centroids
+    
+    """
+    df_norm = preprocess_data(df)
+    model = KMeans(n_clusters=4, random_state=0)
+    kmeans = model.fit(df_norm.T)
+    df_labels = pd.DataFrame({"id_station": df_norm.columns, "labels": kmeans.labels_})
+    df_centroids = pd.DataFrame(kmeans.cluster_centers_).reset_index()
+    return {"labels": df_labels, "centroids": df_centroids}
+
+def preprocess_data(df):
+    """Prepare data in order to apply a clustering algorithm
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input data, *i.e.* city-related timeseries, supposed to have
+    `station_id`, `ts` and `nb_bikes` columns
+
+    Returns
+    -------
+    pandas.DataFrame
+        Simpified version of `df`, ready to be used for clustering
+    
+    """
+    # Filter unactive stations
+    max_bikes = df.groupby("station_id")["nb_bikes"].max()
+    unactive_stations = max_bikes[max_bikes==0].index.tolist()
+    active_station_mask = np.logical_not(df['station_id'].isin(unactive_stations))
+    df = df[active_station_mask]
+    # Set timestamps as the DataFrame index and resample it with 5-minute periods
+    df = (df.set_index("ts")
+          .groupby("station_id")["nb_bikes"]
+          .resample("5T")
+          .mean()
+          .bfill())
+    df = df.unstack(0)
+    # Drop week-end records
+    df = df[df.index.weekday < 5]
+    # Gather data regarding hour of the day
+    df['hour'] = df.index.hour
+    df = df.groupby("hour").mean()
+    return df / df.max()

--- a/jitenshea/stats.py
+++ b/jitenshea/stats.py
@@ -3,7 +3,6 @@
 """Statistical methods used for analyzing the shared bike data
 """
 
-
 import numpy as np
 import pandas as pd
 from sklearn.cluster import KMeans

--- a/jitenshea/tasks/bordeaux.py
+++ b/jitenshea/tasks/bordeaux.py
@@ -35,7 +35,6 @@ from luigi.contrib.postgres import CopyToTable, PostgresQuery
 from luigi.format import UTF8, MixedUnicodeBytes
 
 from jitenshea import config
-from jitenshea.controller import insert_rows
 from jitenshea.iodb import db, psql_args, shp2pgsql_args
 from jitenshea.stats import compute_clusters
 

--- a/jitenshea/tasks/bordeaux.py
+++ b/jitenshea/tasks/bordeaux.py
@@ -149,9 +149,6 @@ class CreateSchema(PostgresQuery):
         connection = self.output().connect()
         cursor = connection.cursor()
         sql = self.query.format(schema=self.schema)
-        # print(sql)
-        # print(extract_tablename(self.table))
-        # logger.info('Executing query from task: {name}'.format(name=self.__class__))
         cursor.execute(sql)
         # Update marker table
         self.output().touch(connection)
@@ -461,23 +458,18 @@ class Clustering(PostgresQuery):
         model = KMeans(n_clusters=4, random_state=0)
         kmeans = model.fit(df_norm.T)
         labels = pd.Series(kmeans.labels_)
-        print(df.iloc[:5, :5])
         df_labels = pd.DataFrame({"id_station": df.columns, "labels": kmeans.labels_})
-        print(df_labels.head(10))
         df_centroids = pd.DataFrame(kmeans.cluster_centers_).reset_index()
-        print(df_centroids.head(10))
         insert_query = "INSERT INTO {} VALUES ({});"
         for _, row in df_labels.iterrows():
             table = ".".join([config["bordeaux"]["schema"],
                               config["bordeaux"]["clustering"]])
             values = ", ".join(str(rv) for rv in row.values)
-            print(values)
             cursor.execute(insert_query.format(table, values))
         for _, row in df_centroids.iterrows():
             table = ".".join([config["bordeaux"]["schema"],
                               config["bordeaux"]["centroids"]])
             values = ", ".join(str(rv) for rv in row.values)
-            print(values)
             cursor.execute(insert_query.format(table, values))
         # Update marker table
         self.output().touch(connection)

--- a/jitenshea/tasks/bordeaux.py
+++ b/jitenshea/tasks/bordeaux.py
@@ -460,7 +460,6 @@ class BordeauxStoreCentroidsToDatabase(CopyToTable):
     def rows(self):
         inputpath = self.input().path
         clusters = pd.read_hdf(inputpath, 'centroids')
-        print(clusters.head())
         for _, row in clusters.iterrows():
             modified_row = list(row.values)
             modified_row[0] = int(modified_row[0])

--- a/jitenshea/tasks/bordeaux.py
+++ b/jitenshea/tasks/bordeaux.py
@@ -417,8 +417,9 @@ class CreateCentroidTable(PostgresQuery):
         connection.close()
 
 class BordeauxComputeClusters(luigi.Task):
-    """Compute clusters corresponding to bike availability on a given `city`
+    """Compute clusters corresponding to bike availability in bordeaux stations
     between a `start` and an `end` date
+
     """
     start = luigi.DateParameter(default=yesterday())
     stop = luigi.DateParameter(default=date.today())
@@ -454,7 +455,9 @@ class BordeauxComputeClusters(luigi.Task):
         clusters['centroids'].to_hdf(path, '/centroids')
 
 class BordeauxStoreClustersToDatabase(CopyToTable):
-    """
+    """Read the cluster labels from `DATADIR/bordeaux-clustering.h5` file and store
+    them into `clustered_stations`
+
     """
     start = luigi.DateParameter(default=yesterday())
     stop = luigi.DateParameter(default=date.today())
@@ -469,8 +472,6 @@ class BordeauxStoreClustersToDatabase(CopyToTable):
                ('cluster_id', 'INT')]
 
     def rows(self):
-        """overload the rows method to skip the first line (header)
-        """
         inputpath = self.input().path
         clusters = pd.read_hdf(inputpath, 'clusters')
         for _, row in clusters.iterrows():
@@ -480,7 +481,9 @@ class BordeauxStoreClustersToDatabase(CopyToTable):
         return BordeauxComputeClusters(self.start, self.stop)
 
 class BordeauxStoreCentroidsToDatabase(CopyToTable):
-    """
+    """Read the cluster centroids from `DATADIR/bordeaux-clustering.h5` file and
+    store them into `centroids`
+
     """
     start = luigi.DateParameter(default=yesterday())
     stop = luigi.DateParameter(default=date.today())
@@ -501,8 +504,6 @@ class BordeauxStoreCentroidsToDatabase(CopyToTable):
         return self.first_column
 
     def rows(self):
-        """overload the rows method to skip the first line (header)
-        """
         inputpath = self.input().path
         clusters = pd.read_hdf(inputpath, 'centroids')
         print(clusters.head())
@@ -515,7 +516,8 @@ class BordeauxStoreCentroidsToDatabase(CopyToTable):
         return BordeauxComputeClusters(self.start, self.stop)
 
 class BordeauxClustering(luigi.Task):
-    """
+    """Clustering master task
+
     """
     start = luigi.DateParameter(default=yesterday())
     stop = luigi.DateParameter(default=date.today())

--- a/jitenshea/tasks/bordeaux.py
+++ b/jitenshea/tasks/bordeaux.py
@@ -425,7 +425,9 @@ class BordeauxComputeClusters(luigi.Task):
     stop = luigi.DateParameter(default=date.today())
 
     def outputpath(self):
-        fname = "-".join(["bordeaux", "clustering.h5"])
+        start_date = self.start.strftime("%Y%m%d")
+        stop_date = self.stop.strftime("%Y%m%d")
+        fname = "bordeaux-{}-{}-clustering.h5".format(start_date, stop_date)
         return os.path.join(DATADIR, fname)
 
     def output(self):

--- a/jitenshea/tasks/bordeaux.py
+++ b/jitenshea/tasks/bordeaux.py
@@ -26,7 +26,9 @@ import sh
 
 import requests
 
+import numpy as np
 import pandas as pd
+from sklearn.cluster import KMeans
 
 import luigi
 from luigi.contrib.postgres import CopyToTable, PostgresQuery
@@ -355,3 +357,130 @@ class AggregateVCUBTransactionIntoDB(CopyToTable):
 
     def requires(self):
         return AggregateTransaction(self.date)
+
+class CreateClusteredStationTable(PostgresQuery):
+    """
+    """
+    host = 'localhost'
+    database = config['database']['dbname']
+    user = config['database']['user']
+    password = None
+    schema = luigi.Parameter()
+    table = luigi.Parameter()
+    query = ("DROP TABLE IF EXISTS {schema}.{table};"
+             "CREATE TABLE IF NOT EXISTS {schema}.{table} ("
+             "station_id int PRIMARY KEY,"
+             "cluster_id INT"
+             ");")
+
+    def run(self):
+        connection = self.output().connect()
+        cursor = connection.cursor()
+        sql = self.query.format(schema=self.schema, table=self.table)
+        cursor.execute(sql)
+        # Update marker table
+        self.output().touch(connection)
+        # commit and close connection
+        connection.commit()
+        connection.close()
+
+class CreateCentroidTable(PostgresQuery):
+    """
+    """
+    host = 'localhost'
+    database = config['database']['dbname']
+    user = config['database']['user']
+    password = None
+    schema = luigi.Parameter()
+    table = luigi.Parameter()
+    query = ("DROP TABLE IF EXISTS {schema}.{table};"
+             "CREATE TABLE IF NOT EXISTS {schema}.{table} ("
+             "cluster_id int PRIMARY KEY,"
+             "h0 float" +
+             "".join([", h"+str(i)+" float " for i in range(1, 24)]) +
+             ");")
+
+    def run(self):
+        connection = self.output().connect()
+        cursor = connection.cursor()
+        sql = self.query.format(schema=self.schema, table=self.table)
+        cursor.execute(sql)
+        # Update marker table
+        self.output().touch(connection)
+        # commit and close connection
+        connection.commit()
+        connection.close()
+
+class Clustering(PostgresQuery):
+    """Compute clusters corresponding to bike availability on a given `city`
+    between a `start` and an `end` date
+    """
+    start_date = luigi.DateParameter(default=yesterday())
+    end_date = luigi.DateParameter(default=date.today())
+    host = 'localhost'
+    database = config['database']['dbname']
+    user = config['database']['user']
+    password = None
+    schema = config['bordeaux']['schema']
+    table = config['bordeaux']['table']
+    query = ("SELECT gid, ts, available_bike "
+             "FROM {}.{} "
+             "WHERE ts >= %(start)s "
+             "AND ts < %(stop)s;"
+             "")
+
+    def requires(self):
+        return {"timeseries": BicycleStationDatabase(),
+                "stations": CreateClusteredStationTable(schema=self.schema,
+                                                        table=config['bordeaux']['clustering']),
+                "centroids": CreateCentroidTable(schema=self.schema,
+                                                 table=config['bordeaux']['centroids'])}
+
+    def run(self):
+        connection = self.output().connect()
+        cursor = connection.cursor()
+        sql_query = self.query.format(self.schema, self.table)
+        df = pd.io.sql.read_sql_query(sql_query, connection,
+                                      params={"start": self.start_date,
+                                              "stop": self.end_date})
+        df.columns = ["station", "ts", "nb_bikes"]
+        max_bikes = df.groupby("station")["nb_bikes"].max()
+        unactive_stations = max_bikes[max_bikes==0].index.tolist()
+        active_station_mask = np.logical_not(df['station'].isin(unactive_stations))
+        df = df[active_station_mask]
+        df = (df.set_index("ts")
+              .groupby("station")["nb_bikes"]
+              .resample("5T")
+              .mean()
+              .bfill())
+        df = df.unstack(0)
+        df = df[df.index.weekday < 5]
+        df['hour'] = df.index.hour
+        df = df.groupby("hour").mean()
+        df_norm = df / df.max()
+        model = KMeans(n_clusters=4, random_state=0)
+        kmeans = model.fit(df_norm.T)
+        labels = pd.Series(kmeans.labels_)
+        print(df.iloc[:5, :5])
+        df_labels = pd.DataFrame({"id_station": df.columns, "labels": kmeans.labels_})
+        print(df_labels.head(10))
+        df_centroids = pd.DataFrame(kmeans.cluster_centers_).reset_index()
+        print(df_centroids.head(10))
+        insert_query = "INSERT INTO {} VALUES ({});"
+        for _, row in df_labels.iterrows():
+            table = ".".join([config["bordeaux"]["schema"],
+                              config["bordeaux"]["clustering"]])
+            values = ", ".join(str(rv) for rv in row.values)
+            print(values)
+            cursor.execute(insert_query.format(table, values))
+        for _, row in df_centroids.iterrows():
+            table = ".".join([config["bordeaux"]["schema"],
+                              config["bordeaux"]["centroids"]])
+            values = ", ".join(str(rv) for rv in row.values)
+            print(values)
+            cursor.execute(insert_query.format(table, values))
+        # Update marker table
+        self.output().touch(connection)
+        # commit and close connection
+        connection.commit()
+        connection.close()

--- a/jitenshea/tasks/lyon.py
+++ b/jitenshea/tasks/lyon.py
@@ -27,7 +27,6 @@ from luigi.format import UTF8, MixedUnicodeBytes
 import pandas as pd
 
 from jitenshea import config
-from jitenshea.controller import insert_rows
 from jitenshea.iodb import db, psql_args, shp2pgsql_args
 from jitenshea.stats import compute_clusters
 

--- a/jitenshea/tasks/lyon.py
+++ b/jitenshea/tasks/lyon.py
@@ -431,13 +431,18 @@ class LyonStoreClustersToDatabase(CopyToTable):
     table = '{schema}.{tablename}'.format(schema=config['lyon']['schema'],
                                           tablename=config['lyon']['clustering'])
     columns = [('station_id', 'INT'),
+               ('start', 'DATE'),
+               ('stop', 'DATE'),
                ('cluster_id', 'INT')]
 
     def rows(self):
         inputpath = self.input().path
         clusters = pd.read_hdf(inputpath, 'clusters')
         for _, row in clusters.iterrows():
-            yield row.values
+            modified_row = list(row.values)
+            modified_row.insert(1, self.stop)
+            modified_row.insert(1, self.start)
+            yield modified_row
 
     def requires(self):
         return LyonComputeClusters(self.start, self.stop)
@@ -456,14 +461,16 @@ class LyonStoreCentroidsToDatabase(CopyToTable):
     password = None
     table = '{schema}.{tablename}'.format(schema=config['lyon']['schema'],
                                           tablename=config['lyon']['centroids'])
-    first_column = [('cluster_id', 'INT')]
+    first_columns = [('cluster_id', 'INT'),
+                     ('start', 'DATE'),
+                     ('stop', 'DATE')]
 
     @property
     def columns(self):
-        if len(self.first_column) == 1:
-            self.first_column.extend([('h'+str(i), 'DOUBLE PRECISION')
+        if len(self.first_columns) == 3:
+            self.first_columns.extend([('h'+str(i), 'DOUBLE PRECISION')
                                       for i in range(24)])
-        return self.first_column
+        return self.first_columns
 
     def rows(self):
         inputpath = self.input().path
@@ -472,6 +479,8 @@ class LyonStoreCentroidsToDatabase(CopyToTable):
         for _, row in clusters.iterrows():
             modified_row = list(row.values)
             modified_row[0] = int(modified_row[0])
+            modified_row.insert(1, self.stop)
+            modified_row.insert(1, self.start)
             yield modified_row
 
     def requires(self):

--- a/jitenshea/tasks/lyon.py
+++ b/jitenshea/tasks/lyon.py
@@ -385,7 +385,9 @@ class LyonComputeClusters(luigi.Task):
     stop = luigi.DateParameter(default=date.today())
 
     def outputpath(self):
-        fname = "-".join(["lyon", "clustering.h5"])
+        start_date = self.start.strftime("%Y%m%d")
+        stop_date = self.stop.strftime("%Y%m%d")
+        fname = "lyon-{}-{}-clustering.h5".format(start_date, stop_date)
         return os.path.join(DATADIR, fname)
 
     def output(self):

--- a/jitenshea/tasks/lyon.py
+++ b/jitenshea/tasks/lyon.py
@@ -316,67 +316,6 @@ class AggregateLyonTransactionIntoDB(CopyToTable):
     def requires(self):
         return AggregateTransaction(self.date)
 
-class CreateClusteredStationTable(PostgresQuery):
-    """Create the `clustered_stations` table in `lyon` scheme
-    """
-    host = 'localhost'
-    database = config['database']['dbname']
-    user = config['database']['user']
-    password = None
-    schema = luigi.Parameter()
-    tablename = luigi.Parameter()
-    query = ("DROP TABLE IF EXISTS {schema}.{table};"
-             "CREATE TABLE IF NOT EXISTS {schema}.{table} ("
-             "station_id int PRIMARY KEY,"
-             "cluster_id INT"
-             ");")
-
-    @property
-    def table(self):
-        return ".".join([self.schema, self.tablename])
-
-    def run(self):
-        connection = self.output().connect()
-        cursor = connection.cursor()
-        sql = self.query.format(schema=self.schema, table=self.tablename)
-        cursor.execute(sql)
-        # Update marker table
-        self.output().touch(connection)
-        # commit and close connection
-        connection.commit()
-        connection.close()
-
-class CreateCentroidTable(PostgresQuery):
-    """Create the `centroids` table in `lyon` scheme
-    """
-    host = 'localhost'
-    database = config['database']['dbname']
-    user = config['database']['user']
-    password = None
-    schema = luigi.Parameter()
-    tablename = luigi.Parameter()
-    query = ("DROP TABLE IF EXISTS {schema}.{table};"
-             "CREATE TABLE IF NOT EXISTS {schema}.{table} ("
-             "cluster_id int PRIMARY KEY,"
-             "h0 float" +
-             "".join([", h"+str(i)+" float " for i in range(1, 24)]) +
-             ");")
-
-    @property
-    def table(self):
-        return ".".join([self.schema, self.tablename])
-
-    def run(self):
-        connection = self.output().connect()
-        cursor = connection.cursor()
-        sql = self.query.format(schema=self.schema, table=self.tablename)
-        cursor.execute(sql)
-        # Update marker table
-        self.output().touch(connection)
-        # commit and close connection
-        connection.commit()
-        connection.close()
-
 class LyonComputeClusters(luigi.Task):
     """Compute clusters corresponding to bike availability in lyon stations
     between a `start` and an `end` date
@@ -392,13 +331,6 @@ class LyonComputeClusters(luigi.Task):
 
     def output(self):
         return luigi.LocalTarget(self.outputpath(), format=MixedUnicodeBytes)
-
-    def requires(self):
-        return {"timeseries": VelovStationDatabase(),
-                "stations": CreateClusteredStationTable(schema=config['lyon']['schema'],
-                                                        tablename=config['lyon']['clustering']),
-                "centroids": CreateCentroidTable(schema=config['lyon']['schema'],
-                                                 tablename=config['lyon']['centroids'])}
 
     def run(self):
         query = ("SELECT number, last_update, available_bikes "
@@ -447,6 +379,21 @@ class LyonStoreClustersToDatabase(CopyToTable):
     def requires(self):
         return LyonComputeClusters(self.start, self.stop)
 
+    def create_table(self, connection):
+        if len(self.columns[0]) == 1:
+            # only names of columns specified, no types
+            raise NotImplementedError(("create_table() not implemented for %r "
+                                       "and columns types not specified")
+                                      % self.table)
+        elif len(self.columns[0]) == 2:
+            # if columns is specified as (name, type) tuples
+            coldefs = ','.join('{name} {type}'.format(name=name, type=type)
+                               for name, type in self.columns)
+            query = ("CREATE TABLE {table} ({coldefs}, "
+                     "PRIMARY KEY (station_id, start, stop));"
+                     "").format(table=self.table, coldefs=coldefs)
+            connection.cursor().execute(query)
+
 class LyonStoreCentroidsToDatabase(CopyToTable):
     """Read the cluster centroids from `DATADIR/lyon-clustering.h5` file and store
     them into `centroids`
@@ -485,6 +432,21 @@ class LyonStoreCentroidsToDatabase(CopyToTable):
 
     def requires(self):
         return LyonComputeClusters(self.start, self.stop)
+
+    def create_table(self, connection):
+        if len(self.columns[0]) == 1:
+            # only names of columns specified, no types
+            raise NotImplementedError(("create_table() not implemented for %r "
+                                       "and columns types not specified")
+                                      % self.table)
+        elif len(self.columns[0]) == 2:
+            # if columns is specified as (name, type) tuples
+            coldefs = ','.join('{name} {type}'.format(name=name, type=type)
+                               for name, type in self.columns)
+            query = ("CREATE TABLE {table} ({coldefs}, "
+                     "PRIMARY KEY (cluster_id, start, stop));"
+                     "").format(table=self.table, coldefs=coldefs)
+            connection.cursor().execute(query)
 
 class LyonClustering(luigi.Task):
     """Clustering master task

--- a/jitenshea/tasks/lyon.py
+++ b/jitenshea/tasks/lyon.py
@@ -125,9 +125,6 @@ class CreateSchema(PostgresQuery):
         connection = self.output().connect()
         cursor = connection.cursor()
         sql = self.query.format(schema=self.schema)
-        # print(sql)
-        # print(extract_tablename(self.table))
-        # logger.info('Executing query from task: {name}'.format(name=self.__class__))
         cursor.execute(sql)
         # Update marker table
         self.output().touch(connection)
@@ -421,23 +418,18 @@ class Clustering(PostgresQuery):
         model = KMeans(n_clusters=4, random_state=0)
         kmeans = model.fit(df_norm.T)
         labels = pd.Series(kmeans.labels_)
-        print(df.iloc[:5, :5])
         df_labels = pd.DataFrame({"id_station": df.columns, "labels": kmeans.labels_})
-        print(df_labels.head(10))
         df_centroids = pd.DataFrame(kmeans.cluster_centers_).reset_index()
-        print(df_centroids.head(10))
         insert_query = "INSERT INTO {} VALUES ({});"
         for _, row in df_labels.iterrows():
             table = ".".join([config["lyon"]["schema"],
                               config["lyon"]["clustering"]])
             values = ", ".join(str(rv) for rv in row.values)
-            print(values)
             cursor.execute(insert_query.format(table, values))
         for _, row in df_centroids.iterrows():
             table = ".".join([config["lyon"]["schema"],
                               config["lyon"]["centroids"]])
             values = ", ".join(str(rv) for rv in row.values)
-            print(values)
             cursor.execute(insert_query.format(table, values))
         # Update marker table
         self.output().touch(connection)

--- a/jitenshea/tasks/lyon.py
+++ b/jitenshea/tasks/lyon.py
@@ -27,7 +27,7 @@ import pandas as pd
 
 from jitenshea import config
 from jitenshea.iodb import db, psql_args, shp2pgsql_args
-
+from jitenshea.stats import compute_clusters
 
 _HERE = os.path.abspath(os.path.dirname(__file__))
 WFS_RDATA_URL = "https://download.data.grandlyon.com/wfs/rdata"
@@ -400,33 +400,15 @@ class Clustering(PostgresQuery):
         df = pd.io.sql.read_sql_query(sql_query, connection,
                                       params={"start": self.start_date,
                                               "stop": self.end_date})
-        df.columns = ["station", "ts", "nb_bikes"]
-        max_bikes = df.groupby("station")["nb_bikes"].max()
-        unactive_stations = max_bikes[max_bikes==0].index.tolist()
-        active_station_mask = np.logical_not(df['station'].isin(unactive_stations))
-        df = df[active_station_mask]
-        df = (df.set_index("ts")
-              .groupby("station")["nb_bikes"]
-              .resample("5T")
-              .mean()
-              .bfill())
-        df = df.unstack(0)
-        df = df[df.index.weekday < 5]
-        df['hour'] = df.index.hour
-        df = df.groupby("hour").mean()
-        df_norm = df / df.max()
-        model = KMeans(n_clusters=4, random_state=0)
-        kmeans = model.fit(df_norm.T)
-        labels = pd.Series(kmeans.labels_)
-        df_labels = pd.DataFrame({"id_station": df.columns, "labels": kmeans.labels_})
-        df_centroids = pd.DataFrame(kmeans.cluster_centers_).reset_index()
+        df.columns = ["station_id", "ts", "nb_bikes"]
+        clusters = compute_clusters(df)
         insert_query = "INSERT INTO {} VALUES ({});"
-        for _, row in df_labels.iterrows():
+        for _, row in clusters["labels"].iterrows():
             table = ".".join([config["lyon"]["schema"],
                               config["lyon"]["clustering"]])
             values = ", ".join(str(rv) for rv in row.values)
             cursor.execute(insert_query.format(table, values))
-        for _, row in df_centroids.iterrows():
+        for _, row in clusters["centroids"].iterrows():
             table = ".".join([config["lyon"]["schema"],
                               config["lyon"]["centroids"]])
             values = ", ".join(str(rv) for rv in row.values)

--- a/jitenshea/tasks/lyon.py
+++ b/jitenshea/tasks/lyon.py
@@ -378,7 +378,7 @@ class CreateCentroidTable(PostgresQuery):
         connection.close()
 
 class LyonComputeClusters(luigi.Task):
-    """Compute clusters corresponding to bike availability on a given `city`
+    """Compute clusters corresponding to bike availability in lyon stations
     between a `start` and an `end` date
     """
     start = luigi.DateParameter(default=yesterday())
@@ -415,7 +415,9 @@ class LyonComputeClusters(luigi.Task):
         clusters['centroids'].to_hdf(path, '/centroids')
 
 class LyonStoreClustersToDatabase(CopyToTable):
-    """
+    """Read the cluster labels from `DATADIR/lyon-clustering.h5` file and store
+    them into `clustered_stations`
+
     """
     start = luigi.DateParameter(default=yesterday())
     stop = luigi.DateParameter(default=date.today())
@@ -430,8 +432,6 @@ class LyonStoreClustersToDatabase(CopyToTable):
                ('cluster_id', 'INT')]
 
     def rows(self):
-        """overload the rows method to skip the first line (header)
-        """
         inputpath = self.input().path
         clusters = pd.read_hdf(inputpath, 'clusters')
         for _, row in clusters.iterrows():
@@ -441,7 +441,9 @@ class LyonStoreClustersToDatabase(CopyToTable):
         return LyonComputeClusters(self.start, self.stop)
 
 class LyonStoreCentroidsToDatabase(CopyToTable):
-    """
+    """Read the cluster centroids from `DATADIR/lyon-clustering.h5` file and store
+    them into `centroids`
+
     """
     start = luigi.DateParameter(default=yesterday())
     stop = luigi.DateParameter(default=date.today())
@@ -462,8 +464,6 @@ class LyonStoreCentroidsToDatabase(CopyToTable):
         return self.first_column
 
     def rows(self):
-        """overload the rows method to skip the first line (header)
-        """
         inputpath = self.input().path
         clusters = pd.read_hdf(inputpath, 'centroids')
         print(clusters.head())
@@ -476,7 +476,8 @@ class LyonStoreCentroidsToDatabase(CopyToTable):
         return LyonComputeClusters(self.start, self.stop)
 
 class LyonClustering(luigi.Task):
-    """
+    """Clustering master task
+
     """
     start = luigi.DateParameter(default=yesterday())
     stop = luigi.DateParameter(default=date.today())

--- a/jitenshea/tasks/lyon.py
+++ b/jitenshea/tasks/lyon.py
@@ -422,7 +422,6 @@ class LyonStoreCentroidsToDatabase(CopyToTable):
     def rows(self):
         inputpath = self.input().path
         clusters = pd.read_hdf(inputpath, 'centroids')
-        print(clusters.head())
         for _, row in clusters.iterrows():
             modified_row = list(row.values)
             modified_row[0] = int(modified_row[0])

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as fobj:
     LONG_DESCRIPTION = fobj.read()
 
 INSTALL_REQUIRES = ["pandas", "requests", "psycopg2", "luigi", 'sqlalchemy',
-                    'lxml', 'daiquiri', 'flask-restplus', 'sh']
+                    'lxml', 'daiquiri', 'flask-restplus', 'sh', 'scikit-learn']
 
 setuptools.setup(
     name='jitenshea',

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ import setuptools
 with open("README.md") as fobj:
     LONG_DESCRIPTION = fobj.read()
 
-INSTALL_REQUIRES = ["pandas", "requests", "psycopg2", "luigi", 'sqlalchemy',
-                    'lxml', 'daiquiri', 'flask-restplus', 'sh', 'scikit-learn']
+INSTALL_REQUIRES = ["pandas", "requests", "psycopg2", "luigi", 'sqlalchemy', 'lxml',
+                    'daiquiri', 'flask-restplus', 'sh', 'scikit-learn', 'tables']
 
 setuptools.setup(
     name='jitenshea',


### PR DESCRIPTION
Add a simple clustering implementation into Luigi data pipeline in order to create tables into the `jitenshea` database : 
- `clustered_stations` : links every station with its cluster
- `centroids` : details the centroids of each cluster, over the 24 hours of the day

This is done for both considered cities (*e.g.* Lyon and Bordeaux).

The corresponding Luigi tasks takes two additional parameters, which are starting and ending dates (default behavior: start=yestarday, end=today). The tasks fail if there is no data at the specified dates.
