### PR TITLE
Luigi XGBoost training

### DIFF
--- a/jitenshea/stats.py
+++ b/jitenshea/stats.py
@@ -1,36 +1,19 @@
-# coding: utf-8
 
 """Statistical methods used for analyzing the shared bike data
 """
 
+import logging
+import daiquiri
+
 import numpy as np
 import pandas as pd
 from sklearn.cluster import KMeans
+import xgboost as xgb
 
 from jitenshea import config
 
-def compute_clusters(df):
-    """Compute station clusters based on bike availability time series
-
-    Parameters
-    ----------
-    df : pandas.DataFrame
-        Input data, *i.e.* city-related timeseries, supposed to have
-    `station_id`, `ts` and `nb_bikes` columns
-
-    Returns
-    -------
-    dict
-        Two pandas.DataFrame, the former for station clusters and the latter
-    for cluster centroids
-    
-    """
-    df_norm = preprocess_data_for_clustering(df)
-    model = KMeans(n_clusters=4, random_state=0)
-    kmeans = model.fit(df_norm.T)
-    df_labels = pd.DataFrame({"id_station": df_norm.columns, "labels": kmeans.labels_})
-    df_centroids = pd.DataFrame(kmeans.cluster_centers_).reset_index()
-    return {"labels": df_labels, "centroids": df_centroids}
+daiquiri.setup(logging.INFO)
+logger = daiquiri.getLogger("stats")
 
 def preprocess_data_for_clustering(df):
     """Prepare data in order to apply a clustering algorithm
@@ -65,3 +48,225 @@ def preprocess_data_for_clustering(df):
     df['hour'] = df.index.hour
     df = df.groupby("hour").mean()
     return df / df.max()
+
+def compute_clusters(df):
+    """Compute station clusters based on bike availability time series
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input data, *i.e.* city-related timeseries, supposed to have
+    `station_id`, `ts` and `nb_bikes` columns
+
+    Returns
+    -------
+    dict
+        Two pandas.DataFrame, the former for station clusters and the latter
+    for cluster centroids
+
+    """
+    df_norm = preprocess_data_for_clustering(df)
+    model = KMeans(n_clusters=4, random_state=0)
+    kmeans = model.fit(df_norm.T)
+    df_labels = pd.DataFrame({"id_station": df_norm.columns, "labels": kmeans.labels_})
+    df_centroids = pd.DataFrame(kmeans.cluster_centers_).reset_index()
+    return {"labels": df_labels, "centroids": df_centroids}
+
+def time_resampling(df, freq="10T"):
+    """Normalize the timeseries by resampling its timestamps
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input data, contains columns `ts`, `nb_bikes`, `nb_stands`, `station_id`
+    freq : str
+        Time resampling frequency
+
+    Returns
+    -------
+    pandas.DataFrame
+        Resampled data
+    """
+    logger.info("Time resampling for each station by '%s'", freq)
+    df = (df.groupby("station_id")
+          .resample(freq, on="ts")[["ts", "nb_bikes", "nb_stands", "probability"]]
+          .mean()
+          .bfill())
+    return df.reset_index()
+
+def complete_data(df):
+    """Add some temporal columns to the dataset
+
+    - day of the week
+    - hour of the day
+    - minute (10 by 10)
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input data ; must contain a `ts` column
+
+    Returns
+    -------
+    pandas.DataFrame
+        Data with additional columns `day`, `hour` and `minute`
+
+    """
+    logger.info("Complete some data")
+    def group_minute(value):
+        if value <= 10:
+            return 0
+        if value <= 20:
+            return 10
+        if value <= 30:
+            return 20
+        if value <= 40:
+            return 30
+        if value <= 50:
+            return 40
+        return 50
+    df = df.copy()
+    df['day'] = df['ts'].apply(lambda x: x.weekday())
+    df['hour'] = df['ts'].apply(lambda x: x.hour)
+    minute = df['ts'].apply(lambda x: x.minute)
+    df['minute'] = minute.apply(group_minute)
+    return df
+
+def add_future(df, frequency):
+    """Add future bike availability to each observation by shifting input data
+    accurate columns with respect to a given `frequency`
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input data
+    frequency : DateOffset, timedelta or str
+        Indicates the prediction frequency
+
+    Returns
+    -------
+    pd.DataFrame
+        Enriched data, with additional column "future"
+    """
+    logger.info("Compute the future bike availability (freq='%s')", frequency)
+    df = df.set_index(["ts", "station_id"])
+    label = df["probability"].copy()
+    label.name = "future"
+    label = (label.reset_index(level=1)
+             .shift(-1, freq=frequency)
+             .reset_index()
+             .set_index(["ts", "station_id"]))
+    logger.info("Merge future data with current observations")
+    df = df.merge(label, left_index=True, right_index=True)
+    df.reset_index(level=1, inplace=True)
+    return df
+
+def prepare_data_for_training(df, date, frequency='1H', start=None, periods=1):
+    """Prepare data for training
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input data; must contains a "future" column and a `datetime` index
+    date : date.datetime
+        Date for the prediction
+    frequency : str
+        Delay between the training and validation set; corresponds to
+    prediction frequency
+    start : date.Timestamp
+        Start of the history data (for training)
+    periods : int
+        Number of predictions
+
+    Returns
+    -------
+    tuple of 4 pandas.DataFrames
+        two for training, two for testing (train_X, train_Y, test_X, test_Y)
+    """
+    logger.info("Split train and test according to a validation date")
+    cut = date - pd.Timedelta(frequency.replace('T', 'm'))
+    stop = date + periods * pd.Timedelta(frequency.replace('T', 'm'))
+    if start is not None:
+        df = df[df.index >= start]
+    logger.info("Data shape after start cut: %s", df.shape)
+    train = df[df.index <= cut].copy()
+    logger.info("Data shape after prediction date cut: %s", df.shape)
+    train_X = train.drop(["probability", "future"], axis=1)
+    train_Y = train['future'].copy()
+    # time window
+    mask = np.logical_and(df.index >= date, df.index <= stop)
+    test = df[mask].copy()
+    test_X = test.drop(["probability", "future"], axis=1)
+    test_Y = test['future'].copy()
+    return train_X, train_Y, test_X, test_Y
+
+def fit(train_X, train_Y, test_X, test_Y):
+    """Train the xgboost model
+
+    Parameters
+    ----------
+    train_X : pandas.DataFrame
+    test_X : pandas.DataFrame
+    train_Y : pandas.DataFrame
+    test_Y : pandas.DataFrame
+
+    Returns
+    -------
+    XGBoost.model
+        Booster trained model
+    """
+    logger.info("Fit training data with the model...")
+    # param = {'objective': 'reg:linear'}
+    param = {'objective': 'reg:logistic'}
+    param['eta'] = 0.2
+    param['max_depth'] = 6
+    param['silent'] = 1
+    param['nthread'] = 4
+    # used num_class only for classification (e.g. a level of availability)
+    # param = {'objective': 'multi:softmax'}
+    # param['num_class'] = train_Y.nunique()
+    training_progress = dict()
+    xg_train = xgb.DMatrix(train_X, label=train_Y)
+    xg_test = xgb.DMatrix(test_X, label=test_Y)
+    watchlist = [(xg_train, 'train'), (xg_test, 'test')]
+    num_round = 25
+    bst = xgb.train(params=param,
+                    dtrain=xg_train,
+                    num_boost_round=num_round,
+                    evals=watchlist,
+                    evals_result=training_progress)
+    return bst, training_progress
+
+def train_prediction_model(df, validation_date, frequency):
+    """Train a XGBoost model on `df` data with a train/validation split given
+    by `predict_date` starting from temporal information (time of the day, day
+    of the week) and previous bike availability
+    
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input data, contains columns `ts`, `nb_bikes`, `nb_stands`,
+    `station_id`
+    validation_date : datetime.date
+        Reference date to split the input data between training and validation
+    sets
+    frequency : DateOffset, timedelta or str
+        Indicates the prediction frequency
+
+    Returns
+    -------
+    XGBoost.model
+        Trained XGBoost model
+
+    """
+    df = time_resampling(df)
+    df = complete_data(df)
+    df = add_future(df, frequency)
+    train_test_split = prepare_data_for_training(df,
+                                                 validation_date,
+                                                 frequency=frequency,
+                                                 start=df.index.min(),
+                                                 periods=2)
+    train_X, train_Y, test_X, test_Y = train_test_split
+    trained_model = fit(train_X, train_Y, test_X, test_Y)
+    return trained_model[0]

--- a/jitenshea/stats.py
+++ b/jitenshea/stats.py
@@ -28,7 +28,7 @@ def preprocess_data_for_clustering(df):
     -------
     pandas.DataFrame
         Simpified version of `df`, ready to be used for clustering
-    
+
     """
     # Filter unactive stations
     max_bikes = df.groupby("station_id")["nb_bikes"].max()
@@ -222,9 +222,6 @@ def fit(train_X, train_Y, test_X, test_Y):
     param['max_depth'] = 6
     param['silent'] = 1
     param['nthread'] = 4
-    # used num_class only for classification (e.g. a level of availability)
-    # param = {'objective': 'multi:softmax'}
-    # param['num_class'] = train_Y.nunique()
     training_progress = dict()
     xg_train = xgb.DMatrix(train_X, label=train_Y)
     xg_test = xgb.DMatrix(test_X, label=test_Y)
@@ -241,7 +238,7 @@ def train_prediction_model(df, validation_date, frequency):
     """Train a XGBoost model on `df` data with a train/validation split given
     by `predict_date` starting from temporal information (time of the day, day
     of the week) and previous bike availability
-    
+
     Parameters
     ----------
     df : pandas.DataFrame

--- a/jitenshea/stats.py
+++ b/jitenshea/stats.py
@@ -99,7 +99,7 @@ def complete_data(df):
 
     - day of the week
     - hour of the day
-    - minute (10 by 10)
+    - minute
 
     Parameters
     ----------
@@ -113,23 +113,10 @@ def complete_data(df):
 
     """
     logger.info("Complete some data")
-    def group_minute(value):
-        if value <= 10:
-            return 0
-        if value <= 20:
-            return 10
-        if value <= 30:
-            return 20
-        if value <= 40:
-            return 30
-        if value <= 50:
-            return 40
-        return 50
     df = df.copy()
     df['day'] = df['ts'].apply(lambda x: x.weekday())
     df['hour'] = df['ts'].apply(lambda x: x.hour)
-    minute = df['ts'].apply(lambda x: x.minute)
-    df['minute'] = minute.apply(group_minute)
+    df['minute'] = df['ts'].apply(lambda x: x.minute)
     return df
 
 def add_future(df, frequency):

--- a/jitenshea/tasks/bordeaux.py
+++ b/jitenshea/tasks/bordeaux.py
@@ -516,7 +516,7 @@ class BordeauxTrainXGBoost(luigi.Task):
     """
     start = luigi.DateParameter(default=yesterday())
     stop = luigi.DateParameter(default=date.today())
-    validation = luigi.DateMinuteParameter(default=date.today()-timedelta(hours=1))
+    validation = luigi.DateMinuteParameter(default=dt.now() - timedelta(hours=1))
     frequency = luigi.Parameter(default="30T")
 
     def outputpath(self):

--- a/jitenshea/tasks/bordeaux.py
+++ b/jitenshea/tasks/bordeaux.py
@@ -520,14 +520,10 @@ class BordeauxTrainXGBoost(luigi.Task):
     frequency = luigi.Parameter(default="30T")
 
     def outputpath(self):
-        start_date = self.start.strftime("%Y%m%d")
-        stop_date = self.stop.strftime("%Y%m%d")
-        validation_date = self.validation.strftime("%Y%m%dT%H%M")
-        fname = "bordeaux-{}-{}-{}-{}.xgboost.model".format(start_date,
-                                                        stop_date,
-                                                        validation_date,
-                                                        self.frequency)
-        return os.path.join(DATADIR, fname)
+        fname = "{}-to-{}-at-{}-freq-{}.model".format(self.start, self.stop,
+                                           self.validation.isoformat(),
+                                           self.frequency)
+        return os.path.join(DATADIR, 'xgboost-model', fname)
 
     def output(self):
         return luigi.LocalTarget(self.outputpath(), format=MixedUnicodeBytes)

--- a/jitenshea/tasks/bordeaux.py
+++ b/jitenshea/tasks/bordeaux.py
@@ -533,7 +533,7 @@ class BordeauxTrainXGBoost(luigi.Task):
         return luigi.LocalTarget(self.outputpath(), format=MixedUnicodeBytes)
 
     def run(self):
-        query = ("SELECT DISTINCT gid AS station_id, ts, "
+        query = ("SELECT DISTINCT ident AS station_id, ts, "
                  "available_bike AS nb_bikes, "
                  "available_stand AS nb_stands, "
                  "available_bike::float / (available_bike::float "

--- a/jitenshea/tasks/lyon.py
+++ b/jitenshea/tasks/lyon.py
@@ -447,6 +447,7 @@ class LyonStoreCentroidsToDatabase(CopyToTable):
                      "").format(table=self.table, coldefs=coldefs)
             connection.cursor().execute(query)
 
+
 class LyonClustering(luigi.Task):
     """Clustering master task
 
@@ -457,6 +458,7 @@ class LyonClustering(luigi.Task):
     def requires(self):
         yield LyonStoreClustersToDatabase(self.start, self.stop)
         yield LyonStoreCentroidsToDatabase(self.start, self.stop)
+
 
 class LyonTrainXGBoost(luigi.Task):
     """Train a XGBoost model between `start` and `stop` dates to predict bike
@@ -474,7 +476,6 @@ class LyonTrainXGBoost(luigi.Task):
     XGBoost model training
     frequency : DateOffset, timedelta or str
         Indicates the prediction frequency
-    
     """
     start = luigi.DateParameter(default=yesterday())
     stop = luigi.DateParameter(default=date.today())

--- a/jitenshea/tasks/lyon.py
+++ b/jitenshea/tasks/lyon.py
@@ -507,8 +507,9 @@ class LyonTrainXGBoost(luigi.Task):
         df = pd.io.sql.read_sql_query(query, eng,
                                       params={"start": self.start,
                                               "stop": self.stop})
-        prediction_model = train_prediction_model(df,
-                                                  self.validation,
-                                                  self.frequency)
-        path = self.output().path
-        prediction_model.save_model(path)
+        if df.empty:
+            raise Exception("There is not any data to process in the DataFrame. "
+                            + "Please check the dates.")
+        prediction_model = train_prediction_model(df, self.validation, self.frequency)
+        self.output().makedirs()
+        prediction_model.save_model(self.output().path)

--- a/jitenshea/tasks/lyon.py
+++ b/jitenshea/tasks/lyon.py
@@ -482,14 +482,10 @@ class LyonTrainXGBoost(luigi.Task):
     frequency = luigi.Parameter(default="30T")
 
     def outputpath(self):
-        start_date = self.start.strftime("%Y%m%d")
-        stop_date = self.stop.strftime("%Y%m%d")
-        validation_date = self.validation.strftime("%Y%m%dT%H%M")
-        fname = "lyon-{}-{}-{}-{}.xgboost.model".format(start_date,
-                                                        stop_date,
-                                                        validation_date,
-                                                        self.frequency)
-        return os.path.join(DATADIR, fname)
+        fname = "{}-to-{}-at-{}-freq-{}.model".format(self.start, self.stop,
+                                           self.validation.isoformat(),
+                                           self.frequency)
+        return os.path.join(DATADIR, 'xgboost-model', fname)
 
     def output(self):
         return luigi.LocalTarget(self.outputpath(), format=MixedUnicodeBytes)

--- a/jitenshea/tasks/lyon.py
+++ b/jitenshea/tasks/lyon.py
@@ -28,7 +28,7 @@ import pandas as pd
 
 from jitenshea import config
 from jitenshea.iodb import db, psql_args, shp2pgsql_args
-from jitenshea.stats import compute_clusters
+from jitenshea.stats import compute_clusters, train_prediction_model
 
 _HERE = os.path.abspath(os.path.dirname(__file__))
 WFS_RDATA_URL = "https://download.data.grandlyon.com/wfs/rdata"
@@ -457,3 +457,62 @@ class LyonClustering(luigi.Task):
     def requires(self):
         yield LyonStoreClustersToDatabase(self.start, self.stop)
         yield LyonStoreCentroidsToDatabase(self.start, self.stop)
+
+class LyonTrainXGBoost(luigi.Task):
+    """Train a XGBoost model between `start` and `stop` dates to predict bike
+    availability at each station
+
+    Attributes
+    ----------
+    start : luigi.DateParameter
+        Training start date
+    stop : luigi.DataParameter
+        Training stop date upper bound (actually the end date is computed with
+    `validation`)
+    validation : luigi.DateMinuteParameter
+        Date that bounds the training set and the validation set during the
+    XGBoost model training
+    frequency : DateOffset, timedelta or str
+        Indicates the prediction frequency
+    
+    """
+    start = luigi.DateParameter(default=yesterday())
+    stop = luigi.DateParameter(default=date.today())
+    validation = luigi.DateMinuteParameter(default=date.today()-timedelta(hours=1))
+    frequency = luigi.Parameter(default="30T")
+
+    def outputpath(self):
+        start_date = self.start.strftime("%Y%m%d")
+        stop_date = self.stop.strftime("%Y%m%d")
+        validation_date = self.validation.strftime("%Y%m%dT%H%M")
+        fname = "lyon-{}-{}-{}-{}.xgboost.model".format(start_date,
+                                                        stop_date,
+                                                        validation_date,
+                                                        self.frequency)
+        return os.path.join(DATADIR, fname)
+
+    def output(self):
+        return luigi.LocalTarget(self.outputpath(), format=MixedUnicodeBytes)
+
+    def run(self):
+        query = ("SELECT DISTINCT number AS station_id, last_update AS ts, "
+                 "available_bikes AS nb_bikes, "
+                 "available_bike_stands AS nb_stands, "
+                 "available_bikes::float / (available_bikes::float "
+                 "+ available_bike_stands::float) AS probability "
+                 "FROM {}.{} "
+                 "WHERE last_update >= %(start)s "
+                 "AND last_update < %(stop)s "
+                 "AND (available_bikes > 0 OR available_bike_stands > 0) "
+                 "AND status = 'OPEN'"
+                 "ORDER BY station_id, ts"
+                 ";").format(config['lyon']['schema'], config['lyon']['table'])
+        eng = db()
+        df = pd.io.sql.read_sql_query(query, eng,
+                                      params={"start": self.start,
+                                              "stop": self.stop})
+        prediction_model = train_prediction_model(df,
+                                                  self.validation,
+                                                  self.frequency)
+        path = self.output().path
+        prediction_model.save_model(path)


### PR DESCRIPTION
Implement the XGBoost method in Luigi pipeline for Lyon and Bordeaux cities. This PR proposes to add model training into the pipeline only, the prediction will be considered in a further PR.

What has been developed:
* in `stats.py`:
  - a `time_resampling()` method in order to resample the input data with a given time frequency (*e.g.* 10 minutes)
  - a `complete_data()` method that make appear `day`, `hour` and `minute` columns, as explicative features
  - a `add_future()` method so as to create the explained **Y** feature: the probability of finding a available bike at a given station one period later (one period = 30 minutes, or one hour, or whatever you want)
  - a `prepare_data_for_training()` method, which splits the input data into distinct training and validation sets.
  - a `fit()` method, that overloads the XGBoost `train()` method
  - a `train_prediction_model()`, that encapsulates the entire training process
* in `lyon.py` and `bordeaux.py`:
  - a CityTrainXGBoost task that queries the city-related database and call the XGBoost trainer on resulting data (through the `train_prediction_model()` method.

The trained XGBoost model is stored as a binary file on the file system; this file will be used for inference by a subsequent task.