### PR TITLE
Clustering app

### DIFF
--- a/jitenshea/static/cluster.js
+++ b/jitenshea/static/cluster.js
@@ -1,0 +1,50 @@
+// Jitenshea functions for the 'cluster' web page
+
+function stationsMap(map, data) {
+  var OSM_Mapnik = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+  });
+  OSM_Mapnik.addTo(map);
+  var centroid = turf.center(data);
+  map.setView([centroid.geometry.coordinates[1],
+               centroid.geometry.coordinates[0]], 12);
+  L.geoJSON(data, {
+    style: function(feature){
+      return {color: d3.schemeSet1[feature.properties.cluster_id]};
+    },
+    pointToLayer: function(geoJsonPoint, latlng) {
+      return L.circleMarker(latlng, {radius: 3})
+	.bindPopup("<ul><li><b>ID</b>: " + geoJsonPoint.properties.id
+		   + "</li><li><b>Name</b>: " + geoJsonPoint.properties.name + "</li>"
+		   + "<li><b>Cluster id</b>: " + geoJsonPoint.properties.cluster_id + "</li></ul>")
+	.on('mouseover', function(e) {
+	  this.openPopup();
+	})
+	.on('mouseout', function(e) {
+	  this.closePopup();
+	});
+    }
+  }).addTo(map);
+};
+
+// Map with all stations with Leaflet
+// TODO :
+// TODO :
+//  - is it possible to set a bbox (computed by turjs) instead of a zoom in the
+//    'setView' function.
+$(document).ready(function() {
+  var station_map = L.map("clusteredStationMap");
+  var city = document.getElementById("clusteredStationMap").dataset.city;
+  var geostations = sessionStorage.getItem("cluster_" + city);
+  if (geostations == null) {
+    $.get(cityurl("clusteredStationMap") + "/clustering/stations?geojson=true", function(data) {
+      console.log("stations geodata GET request in " + city);
+      stationsMap(station_map, data);
+      sessionStorage.setItem(city, JSON.stringify(data));
+    } );
+  } else {
+    console.log("station geodata from sesssionStorage in " + city);
+    stationsMap(station_map, JSON.parse(geostations));
+  }
+} );

--- a/jitenshea/static/cluster.js
+++ b/jitenshea/static/cluster.js
@@ -48,3 +48,64 @@ $(document).ready(function() {
     stationsMap(station_map, JSON.parse(geostations));
   }
 } );
+
+
+// Timeseries plot
+$(document).ready(function() {
+  var url = cityurl("clusterCentroids") + "/clustering/centroids";
+  $.get(url, function(content) {
+
+    var cluster0 = content.data[0].hour.map(function(t, i) {
+      return [t, content.data[0].values[i]];
+    });
+    var cluster1 = content.data[1].hour.map(function(t, i) {
+      return [t, content.data[1].values[i]];
+    });
+    var cluster2 = content.data[2].hour.map(function(t, i) {
+      return [t, content.data[2].values[i]];
+    });
+    var cluster3 = content.data[3].hour.map(function(t, i) {
+      return [t, content.data[3].values[i]];
+    });
+
+    Highcharts.chart('clusterCentroids', {
+      title: {
+        text: 'Cluster centroid definitions'
+      },
+      yAxis: {
+        title: {
+          text: 'Available bike percentage'
+        }
+      },
+      xAxis: {
+        type: "Hour of the day"
+      },
+      colors: d3.schemeSet1,
+      series: [{
+        name: "cluster 0",
+        data: cluster0,
+        tooltip: {
+          valueDecimals: 2
+        }
+      },{
+        name: "cluster 1",
+        data: cluster1,
+        tooltip: {
+          valueDecimals: 2
+        }
+      },{
+        name: "cluster 2",
+        data: cluster2,
+        tooltip: {
+          valueDecimals: 2
+        }
+      },{
+        name: "cluster 3",
+        data: cluster3,
+        tooltip: {
+          valueDecimals: 2
+        }
+      }]
+    } );
+  } );
+} );

--- a/jitenshea/static/cluster.js
+++ b/jitenshea/static/cluster.js
@@ -55,18 +55,14 @@ $(document).ready(function() {
   var url = cityurl("clusterCentroids") + "/clustering/centroids";
   $.get(url, function(content) {
 
-    var cluster0 = content.data[0].hour.map(function(t, i) {
-      return [t, content.data[0].values[i]];
-    });
-    var cluster1 = content.data[1].hour.map(function(t, i) {
-      return [t, content.data[1].values[i]];
-    });
-    var cluster2 = content.data[2].hour.map(function(t, i) {
-      return [t, content.data[2].values[i]];
-    });
-    var cluster3 = content.data[3].hour.map(function(t, i) {
-      return [t, content.data[3].values[i]];
-    });
+    function mapCentroidValues(id){
+      return content.data[id].hour.map(function(t, i){
+	return [t, content.data[id].values[i]];
+      });
+    };
+    var clusters = {};
+    for (cluster = 0; cluster <= 3; cluster++)
+      clusters[content.data[cluster].cluster_id] = mapCentroidValues(cluster)
 
     Highcharts.chart('clusterCentroids', {
       title: {
@@ -83,25 +79,25 @@ $(document).ready(function() {
       colors: d3.schemeSet1,
       series: [{
         name: "cluster 0",
-        data: cluster0,
+        data: clusters[0],
         tooltip: {
           valueDecimals: 2
         }
       },{
         name: "cluster 1",
-        data: cluster1,
+        data: clusters[1],
         tooltip: {
           valueDecimals: 2
         }
       },{
         name: "cluster 2",
-        data: cluster2,
+        data: clusters[2],
         tooltip: {
           valueDecimals: 2
         }
       },{
         name: "cluster 3",
-        data: cluster3,
+        data: clusters[3],
         tooltip: {
           valueDecimals: 2
         }

--- a/jitenshea/templates/cluster.html
+++ b/jitenshea/templates/cluster.html
@@ -1,0 +1,45 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+
+<h2>Station clusters in {{city|capitalize}}</h2>
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item" aria-current="page"><a href="{{url_for('index')}}">Home</a></li>
+    <li class="breadcrumb-item" aria-current="page">
+      <a href="{{url_for('city_view', city=city)}}">{{city|capitalize}}</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Cluster</li>
+  </ol>
+</nav>
+
+<div class="container" id="stationSummary" data-city="{{city}}"
+     data-station-id="{{station_id}}">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-4">
+	<h4>select clustering training data</h4>
+      </div>
+      <div class="col-md-8">
+	<h4>select the cluster</h4>
+      </div>
+    </div>
+  </div>
+
+<h3>Map</h3>
+
+<div class="container">
+  <div id="clusteredStationMap" data-city="{{city}}" style="height: 450px;">
+  </div>
+</div>
+
+<h3>Time series</h3>
+
+<div id="clusterCentroids" data-city="{{city}}" style="width: 100%; height:400px;">
+</div>
+
+{% endblock %}
+
+{% block appjs %}
+<script src="{{ url_for('static', filename='cluster.js') }}" type="text/javascript"></script>
+{% endblock %}

--- a/jitenshea/webapp.py
+++ b/jitenshea/webapp.py
@@ -42,3 +42,9 @@ def city_view(city):
 def station_view(city, station_id):
     check_city(city)
     return render_template('station.html', city=city, station_id=station_id)
+
+
+@app.route("/<string:city>/cluster")
+def clustering_view(city):
+    check_city(city)
+    return render_template("cluster.html", city=city)


### PR DESCRIPTION
This PR aims at creating a clustering-focused page to the web application.

For now, this page is quite basic, the only available information is the station clusters through a Leaflet map and the cluster centroids definition on a typical day by the way of some time series.

A [temporary Firefox screenshot](https://screenshots.firefox.com/4IN9dzlAwAHXflkp/localhost) shows how looks such a page.

It depicts all clusters by default (this behavior may be changed in a near future, in an additional pull request); the considered clusters being the most recent one in `city.clustered_stations` and `city.centroids` tables.