### PR TITLE
Availability prediction

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -6,6 +6,7 @@ port = 5432
 # you can write it if necessary
 password
 
+
 [lyon]
 schema = lyon
 srid = 4326

--- a/jitenshea/tasks/city.py
+++ b/jitenshea/tasks/city.py
@@ -822,7 +822,7 @@ class PredictBikeAvailability(luigi.Task):
                  "AND (status = 'open')"
                  "ORDER BY id, timestamp"
                  ";").format(schema=self.city,
-                             tablename=config['database']['timeseries'])
+                             tablename='timeseries')
         eng = db()
         df = pd.io.sql.read_sql_query(query, eng,
                                       params={"start": self.start,
@@ -867,7 +867,7 @@ class StorePredictionToDatabase(CopyToTable):
     def table(self):
         return '{schema}.{tablename}'.format(
             schema=self.city,
-            tablename=config['database']['predictions'])
+            tablename='prediction')
 
     @property
     def start(self):

--- a/jitenshea/tasks/city.py
+++ b/jitenshea/tasks/city.py
@@ -760,6 +760,7 @@ class TrainXGBoost(luigi.Task):
         df = pd.io.sql.read_sql_query(query, eng,
                                       params={"start": self.start,
                                               "stop": self.stop})
+        df.station_id = df.station_id.astype(int)
         if df.empty:
             raise Exception("There is not any data to process in the DataFrame. "
                             + "Please check the dates.")
@@ -826,6 +827,7 @@ class PredictBikeAvailability(luigi.Task):
         df = pd.io.sql.read_sql_query(query, eng,
                                       params={"start": self.start,
                                               "stop": self.stop})
+        df.station_id = df.station_id.astype(int)
         if df.empty:
             raise Exception("There is not any data to process in the "
                             + "prediction DataFrame. Please check the dates.")


### PR DESCRIPTION
This PR aims at adding predicted bike availability into database.

A previous work was focused on training XGBoost models starting from a range of bike availability measurements. However produced trained models were not exploited yet. The PR goal is to address this, by producing some `csv` files with predictions over a defined-as-argument time horizon; and then, by storing the computed data to the corresponding database.

More concretely, we now have two brand new Luigi tasks, that do these jobs.

This PR fixes issue #4 .
