### PR TITLE
redefine the UTC prediction time horizon

### DIFF
--- a/jitenshea/static/station.js
+++ b/jitenshea/static/station.js
@@ -89,8 +89,8 @@ $(document).ready(function() {
   stop.setDate(stop.getDate() + 1);
   start.setDate(start.getDate() - 7);
 
-  start = start.toISOString().substring(0, 10);
-  stop = stop.toISOString().substring(0, 10);
+  start = toLocaleISOString(start).substring(0, 10);
+  stop = toLocaleISOString(stop).substring(0, 10);
 
   var url = cityurl("stationTimeseries")
       + "/timeseries/station/" + station_id
@@ -165,18 +165,35 @@ $(document).ready(function() {
 } );
 
 
+// Get the "right" date string by considering local timezone
+// as date.toISOString() gives the UTC timezone
+// See https://stackoverflow.com/questions/47219556/why-using-the-toisostring-method-on-a-date-object-the-hourly-value-is-an-hour
+function toLocaleISOString(date) {
+  function pad(number) {
+    if (number < 10) {
+      return '0' + number;
+    }
+    return number;
+  }
+  return date.getFullYear() +
+    '-' + pad(date.getMonth() + 1) +
+    '-' + pad(date.getDate()) +
+    'T' + pad(date.getHours()) +
+    ':' + pad(date.getMinutes()) +
+    ':' + pad(date.getSeconds()) ;
+}
+
+
 // Predictions plot
 $(document).ready(function() {
   var station_id = document.getElementById("stationPredictions").dataset.stationId;
   // Only plot seven days.
-  var start = new Date();
   var stop = new Date();
+  var start = new Date(stop);
   start.setHours(start.getHours() - 1);
   stop.setHours(stop.getHours() + 1);
-  start = start.toISOString().substring(0, 16);
-  stop = stop.toISOString().substring(0, 16);
-  console.log(start);
-  console.log(stop);
+  start = toLocaleISOString(start).substring(0, 16);
+  stop = toLocaleISOString(stop).substring(0, 16);
 
   var url = cityurl("stationPredictions")
       + "/predict/station/" + station_id

--- a/jitenshea/static/station.js
+++ b/jitenshea/static/station.js
@@ -139,7 +139,8 @@ $(document).ready(function() {
         }
       },
       xAxis: {
-        type: "datetime"
+        type: "datetime",
+	ordinal: "false"
       },
       time: {
 	useUTC: false

--- a/jitenshea/webapi.py
+++ b/jitenshea/webapi.py
@@ -140,7 +140,7 @@ predict_parser.add_argument("current", required=False, type=inputs.boolean, defa
                             dest="current", location="args",
                             help="With current values?")
 predict_parser.add_argument("predict_values", type=int,
-                            dest="values_num", default=3, location="args",
+                            dest="values_num", default=5, location="args",
                             help="Number of predict values")
 
 hourly_profile_parser = api.parser()


### PR DESCRIPTION
This PR aims at handling the time horizon bug for prediction timeseries, in station app pages.
As the `toISOString()` function returns the timestamp on the UTC timezone, we get inconsistent information (predictions on past hours...). Hence here were just use a hand-made date-to-string method to catch this fact, according to https://stackoverflow.com/questions/47219556/why-using-the-toisostring-method-on-a-date-object-the-hourly-value-is-an-hour .

As a remark, one may decide later to work only with UTC dates, however this should be notified to users by any way.

Two extra edits:
- 5 last predicted values instead of 3 (so as to cover the entire future hour)
- ordinal parameter of xAxis set to false (x depends on time, not on pixels)

Fix #51 