### PR TITLE
Station set

### DIFF
--- a/jitenshea/controller.py
+++ b/jitenshea/controller.py
@@ -211,7 +211,7 @@ def _query_stations(city, limit=20):
     -------
     str
     """
-    return """SELECT id
+    query = """SELECT id
       ,name
       ,address
       ,city
@@ -219,10 +219,10 @@ def _query_stations(city, limit=20):
       ,st_x(geom) as x
       ,st_y(geom) as y
     FROM {schema}.station
-    LIMIT {limit}
-    """.format(schema=city,
-               limit=limit)
-
+    """.format(schema=city)
+    if limit is not None:
+        query += " LIMIT {limit}".format(limit=limit)
+    return query
 
 def daily_query(city):
     """SQL query to get daily transactions according to the city
@@ -440,12 +440,13 @@ def latest_availability(city, limit, geojson):
     join {city}.station as S using(id)
     where P.rank=1
     order by id
-    limit %(limit)s
     """.format(city=city)
+    if limit is not None:
+        query += " limit {limit}".format(limit=limit)
     eng = db()
     # avoid getting the full history
     min_date = datetime.now() - timedelta(days=2)
-    rset = eng.execute(query, min_date=min_date, limit=limit)
+    rset = eng.execute(query, min_date=min_date)
     keys = rset.keys()
     result = [dict(zip(keys, row)) for row in rset]
     latest_date = max(x['timestamp'] for x in result)
@@ -492,8 +493,9 @@ def latest_predictions(city, limit, geojson, freq='1H'):
     join {city}.station as S using(id)
     where P.rank=1
     order by id
-    limit %(limit)s
     """.format(city=city)
+    if limit is not None:
+        query += " limit {limit}".format(limit=limit)
     eng = db()
     # avoid getting the full history
     min_date = datetime.now() - timedelta(days=2)

--- a/jitenshea/webapi.py
+++ b/jitenshea/webapi.py
@@ -99,7 +99,7 @@ api = Api(title='Jitenshea: Bicycle-sharing data analysis',
 
 # Parsers
 station_list_parser = api.parser()
-station_list_parser.add_argument("limit", required=False, type=int, default=100,
+station_list_parser.add_argument("limit", required=False, type=int,
                                  dest='limit', location='args', help='Limit')
 station_list_parser.add_argument("geojson", required=False, default=False, dest='geojson',
                                  location='args', help='GeoJSON format?')


### PR DESCRIPTION
This PR removes the default parameter to the `station_list_parser`, used for serving station availability and "infostation" data. By doing so, we consider now all the stations by default, hence all the stations are represented on the main city map.

fix #46 