### PR TITLE
Unselect secondary layers on main city map by default

### DIFF
--- a/jitenshea/static/city.js
+++ b/jitenshea/static/city.js
@@ -77,11 +77,11 @@ $(document).ready(function() {
 
   var currentLayer = L.geoJSON(null, {
     pointToLayer: pointToLayer
-  }).addTo(map);
+  });
 
   var predictionLayer = L.geoJSON(null, {
     pointToLayer: pointToLayer
-  }).addTo(map);
+  });
 
   var baseMaps = {
     "info": infoLayer,


### PR DESCRIPTION
This PR simplifies the default loaded information on the main city map. One only gets the infostation bike stations. Selecting other layers is still possible on a second hand through the radio box.

Fix #54 